### PR TITLE
Fix: #81 Fix formatting for FUV, PUM, LIC 0-4

### DIFF
--- a/app/src/test/java/app/decide/FuvTest.java
+++ b/app/src/test/java/app/decide/FuvTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import java.util.Random;
 
 /**
+ * Fuv condition:
  * The Final Unlocking Vector (FUV) is generated from the Preliminary Unlocking Matrix. 
  * The input PUV indicates whether the corresponding LIC is to be considered as a 
  * factor in signaling interceptor launch. FUV[i] should be set to true if PUV[i] 

--- a/app/src/test/java/app/decide/PUMGeneratorTest.java
+++ b/app/src/test/java/app/decide/PUMGeneratorTest.java
@@ -5,15 +5,21 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for the PUMGenerator class.
+ * The Conditions Met Vector (CMV) can now be used in conjunction with the Logical Connector
+ * Matrix (LCM) to form the Preliminary Unlocking Matrix (PUM). The entries in the LCM represent 
+ * the logical connectors to be used between pairs of LICs to determine the corresponding entry in
+ * the PUM, i.e. LCM[i,j] represents the boolean operator to be applied to CMV[i] and CMV[j].
+ * PUM[i,j] is set according to the result of this operation. If LCM[i,j] is NOTUSED, then PUM[i,j]
+ * should be set to true. If LCM[i,j] is ANDD, PUM[i,j] should be set to true only if (CMV[i] AND
+ * CMV[j]) is true. If LCM[i,j] is ORR, PUM[i,j] should be set to true if (CMV[i] OR CMV[j]) is
+ * true. (Note that the LCM is symmetric, i.e. LCM[i,j]=LCM[j,i] for all i and j.)
  */
 public class PUMGeneratorTest {
 
     /**
      * Test for a valid PUM generation with a mix of ANDD, ORR, and NOTUSED.
      */
-    @Test
-    public void testGeneratePUM_ValidInput() {
+    @Test public void testGeneratePUM_ValidInput() {
         // Define a valid 15x15 LCM 
         Decide.CONNECTORS[][] lcm = new Decide.CONNECTORS[15][15];
         for (int i = 0; i < 15; i++) {
@@ -47,8 +53,7 @@ public class PUMGeneratorTest {
     /**
      * Test for an edge case where all connectors in LCM are NOTUSED.
      */
-    @Test
-    public void testGeneratePUM_AllNOTUSED() {
+    @Test public void testGeneratePUM_AllNOTUSED() {
         // Define an LCM where all connectors are NOTUSED
         Decide.CONNECTORS[][] lcm = new Decide.CONNECTORS[15][15];
         for (int i = 0; i < 15; i++) {

--- a/app/src/test/java/app/decide/lic/Lic0Test.java
+++ b/app/src/test/java/app/decide/lic/Lic0Test.java
@@ -4,14 +4,20 @@ import org.junit.jupiter.api.Test;
 
 import app.decide.Decide;
 
-
+/**
+ * Lic0 condition:
+ * There exists at least one set of two consecutive data points that are 
+ * a distance greater than the length, LENGTH1, apart. (0 <= LENGTH1)
+ */
 public class Lic0Test {
     static double[] x;
     static double[] y;
     static Decide.Parameters params;
 
-    @Test
-    void trueCondition() {
+    /**
+     * Should be true since at least one pair of consecutive points exceed LENGTH1
+     */
+    @Test void trueCondition() {
        Lic0 lic = new Lic0();
        double[] x = {0.0, 3.0, 6.0, 9.0, 12.0};  
        double[] y = {0.0, 4.0, 8.0, 12.0, 16.0}; 
@@ -24,9 +30,10 @@ public class Lic0Test {
        boolean condition = lic.condition(x, y, x.length, params);
        Assertions.assertTrue(condition, "Should return true because at least one pair of consecutive points exceeds LENGTH1.");
     }
-
-    @Test
-    void falseCondition() {
+    /**
+     * Should be false since no consecutive pair of points exceed LENGTH1  
+     */
+    @Test void falseCondition() {
        Lic0 lic = new Lic0();
        double[] x = {0.0, 3.0, 6.0, 9.0, 12.0};  
        double[] y = {0.0, 4.0, 8.0, 12.0, 16.0}; 
@@ -38,6 +45,5 @@ public class Lic0Test {
        params.LENGTH1 = 6.0;
        boolean condition = lic.condition(x, y, x.length, params);
        Assertions.assertFalse(condition, "Should return false because no pair of consecutive points exceeds LENGTH1.");
-    }
- 
+    } 
  }

--- a/app/src/test/java/app/decide/lic/Lic1Test.java
+++ b/app/src/test/java/app/decide/lic/Lic1Test.java
@@ -4,7 +4,10 @@ import app.decide.Decide;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
-
+/**
+ * There exists at least one set of three consecutive data points that 
+ * cannot all be contained within or on a circle of radius RADIUS1. (0 <= RADIUS1)
+ */
 class Lic1Test {
     /**
      * When num_points is not the same length, inputs are invalid

--- a/app/src/test/java/app/decide/lic/Lic2Test.java
+++ b/app/src/test/java/app/decide/lic/Lic2Test.java
@@ -5,13 +5,22 @@ import org.junit.jupiter.api.Test;
 
 import app.decide.Decide;
 
+/**
+ * There exists at least one set of three consecutive data points which form an angle such that: 
+ * angle < (PI − EPSILON) or angle > (PI + EPSILON)
+ * The second of the three consecutive points is always the vertex of the angle. If either the first
+ * point or the last point (or both) coincides with the vertex, the angle is undefined and the LIC
+ * is not satisfied by those three points. (0 <= EPSILON <= PI)
+ */
 public class Lic2Test {
     static double[] x;
     static double[] y;
     static Decide.Parameters params;
     
-    @Test
-    void trueCondition() {
+    /**
+     * Should be true since the angle deviates from pi by more than EPSILON
+     */
+    @Test void trueCondition() {
     Lic2 lic = new Lic2();
     double[] x = {0.0, 1.0, 2.0};  
     double[] y = {0.0, 1.0, 0.0};  // Forms an angle ≠ π
@@ -27,8 +36,10 @@ public class Lic2Test {
         "Should return true because the angle deviates from π by more than EPSILON.");
     }
 
-    @Test
-    void falseCondition() {
+    /**
+     * Should be false since there are not enough points to form an angle
+     */
+    @Test void falseCondition() {
     Lic2 lic = new Lic2();
     double[] x = {0.0, 1.0};  
     double[] y = {0.0, 1.0};  // Only two points
@@ -44,9 +55,10 @@ public class Lic2Test {
         "Should return false because there are not enough points to form an angle.");
     }
 
-
-    @Test
-    void falseConditionAngle() {
+    /**
+     * Should be false because the angle is exactly pi and within EPSILON
+     */
+    @Test void falseConditionAngle() {
     Lic2 lic = new Lic2();
     double[] x = {0.0, 2.0, 6.0};  
     double[] y = {0.0, 1.0, 0.0}; 
@@ -61,6 +73,4 @@ public class Lic2Test {
     Assertions.assertFalse(condition, 
         "Should return false because the angle is exactly π and within EPSILON.");
     }
-
-
 }

--- a/app/src/test/java/app/decide/lic/Lic3Test.java
+++ b/app/src/test/java/app/decide/lic/Lic3Test.java
@@ -5,11 +5,16 @@ import org.junit.jupiter.api.Test;
 
 import app.decide.Decide;
 
+/**
+* There exists at least one set of three consecutive data points that are the vertices of a triangle
+* with area greater than AREA1. (0 <= AREA1)
+*/
 public class Lic3Test {
-    
 
-    @Test
-    void trueCondition_AreaExceedsThreshold() {
+    /**
+    * Should be true because at least one triangle has an area greater than AREA1 
+    */
+    @Test void trueCondition() {
         Lic3 lic = new Lic3();
         double[] x = {0.0, 2.0, 4.0};  
         double[] y = {0.0, 3.0, 0.0};  // triangle with area = 6
@@ -25,8 +30,10 @@ public class Lic3Test {
             "Should return true because at least one triangle has an area greater than AREA1.");
     }
 
-    @Test
-    void falseCondition_AllTrianglesBelowThreshold() {
+    /**
+    * Should be false because all triangles have an area <= AREA1 
+    */
+    @Test void falseCondition_AllTrianglesBelowThreshold() {
         Lic3 lic = new Lic3();
         double[] x = {0.0, 1.0, 2.0};  
         double[] y = {0.0, 0.5, 0.0};  // triangle with area = 1/2
@@ -41,5 +48,4 @@ public class Lic3Test {
         Assertions.assertFalse(condition, 
             "Should return false because all triangles have an area ≤ AREA1.");
     }
-
 }

--- a/app/src/test/java/app/decide/lic/Lic4Test.java
+++ b/app/src/test/java/app/decide/lic/Lic4Test.java
@@ -5,12 +5,19 @@ import org.junit.jupiter.api.Test;
 
 import app.decide.Decide;
 
+/**
+ * There exists at least one set of Q PTS consecutive data points that lie in more than QUADS
+ * quadrants. Where there is ambiguity as to which quadrant contains a given point, priority
+ * of decision will be by quadrant number, i.e., I, II, III, IV. For example, the data point (0,0)
+ * is in quadrant I, the point (-l,0) is in quadrant II, the point (0,-l) is in quadrant III, the point
+ * (0,1) is in quadrant I and the point (1,0) is in quadrant I. (2 <= Q_PTS <= NUMPOINTS), (1 <= QUADS <= 3)
+ */
 public class Lic4Test {
-    
-
-
-    @Test
-    void trueCondition() {
+  
+    /**
+     * Should be true since at least one group of Q_PTS spans more than QUADS quadrants
+     */
+    @Test void trueCondition() {
         Lic4 lic = new Lic4();
         double[] x = {1.0, -1.0, -2.0, 2.0};  // in quadrants: I, II, III
         double[] y = {1.0, 1.0, -1.0, 1.0};  
@@ -27,8 +34,10 @@ public class Lic4Test {
             "Should return true because at least one group of Q_PTS points spans more than QUADS quadrants.");
     }
 
-    @Test
-    void falseCondition() {
+    /**
+     * Should be false since all points stay within QUADS quadrants
+     */
+    @Test void falseCondition() {
         Lic4 lic = new Lic4();
         double[] x = {1.0, 2.0, 3.0, 4.0};  // All in quadrant I
         double[] y = {1.0, 2.0, 3.0, 4.0};  


### PR DESCRIPTION
This should make FUV, PUM and LIC 0-4 compliant with standardized test format according to #79 
fixes #81 